### PR TITLE
AWS EKS를 통한 배포 

### DIFF
--- a/cluster.yaml
+++ b/cluster.yaml
@@ -8,4 +8,6 @@ metadata:
 nodeGroups:
   - name: ng-1
     instanceType: t2.micro
-    desiredCapacity: 5
+    desiredCapacity: 3
+    minSize: 3
+    maxSize: 3

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -8,6 +8,4 @@ metadata:
 nodeGroups:
   - name: ng-1
     instanceType: t2.micro
-    desiredCapacity: 3
-    minSize: 3
-    maxSize: 3
+    desiredCapacity: 1

--- a/cluster.yaml
+++ b/cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: secret-forest
+  region: ap-northeast-2
+
+nodeGroups:
+  - name: ng-1
+    instanceType: t2.micro
+    desiredCapacity: 5

--- a/k8s/secret-forest/templates/auth/deployment.yaml
+++ b/k8s/secret-forest/templates/auth/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: auth
     spec:
       containers:
-      - image: asia-northeast3-docker.pkg.dev/secret-forest-oauth/auth/production
+      - image: 699510596669.dkr.ecr.ap-northeast-2.amazonaws.com/auth:latest
         name: auth
         env:
           - name: MONGODB_URI

--- a/k8s/secret-forest/templates/ingress.yaml
+++ b/k8s/secret-forest/templates/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: secret-forest
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    kubernetes.io/ingress.class: alb
 spec:
   rules:
     - http:

--- a/k8s/secret-forest/templates/notifications/deployment.yaml
+++ b/k8s/secret-forest/templates/notifications/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: notifications
     spec:
       containers:
-      - image: asia-northeast3-docker.pkg.dev/secret-forest-oauth/notifications/production
+      - image: 699510596669.dkr.ecr.ap-northeast-2.amazonaws.com/notifications:latest
         name: notifications
         env:
           - name: PORT
@@ -36,4 +36,3 @@ spec:
                 key: refreshToken
         ports:
           - containerPort: 3000
-

--- a/k8s/secret-forest/templates/reservations/deployment.yaml
+++ b/k8s/secret-forest/templates/reservations/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: reservations
     spec:
       containers:
-      - image: asia-northeast3-docker.pkg.dev/secret-forest-oauth/reservations/production
+      - image: 699510596669.dkr.ecr.ap-northeast-2.amazonaws.com/reservations:latest
         name: reservations
         env:
           - name: MONGODB_URI


### PR DESCRIPTION
이제 Route53에서 구매한 도메인으로 바꾸어야한다.